### PR TITLE
Fix readthedocs yaml to build ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,6 +30,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#     - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
There was an issue with the ReadtheDocs build because of the requirements.txt not being properly installed. I made sure to uncomment this in the readthedocs.yaml file.