### PR TITLE
Remove max_tokens from openai backend

### DIFF
--- a/mbodied/__about__.py
+++ b/mbodied/__about__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/mbodied/agents/backends/openai_backend.py
+++ b/mbodied/agents/backends/openai_backend.py
@@ -149,7 +149,6 @@ class OpenAIBackendMixin(Backend):
             model=model,
             messages=serialized_messages,
             temperature=0,
-            max_tokens=1000,
             tools=tools,
             **kwargs,
         )


### PR DESCRIPTION
GPT-5+ doesn't have this arg anymore.